### PR TITLE
fix first thread being skipped

### DIFF
--- a/fbchat/_client.py
+++ b/fbchat/_client.py
@@ -312,7 +312,9 @@ class Client(object):
                 before=last_thread_timestamp, thread_location=thread_location
             )
 
-            if len(candidates) > 1:
+            if last_thread_timestamp == None and len(candidates) >= 1:
+                threads += candidates
+            elif len(candidates) > 1:
                 threads += candidates[1:]
             else:  # End of threads
                 break


### PR DESCRIPTION
Thanks for making a fork of this that actually works with <https://github.com/karlicoss/fbmessengerexport>. This is just a little fix for the last active chat being always skipped.